### PR TITLE
Potential fix for code scanning alert no. 1186: Incomplete URL substring sanitization

### DIFF
--- a/backend/src/services/smee.ts
+++ b/backend/src/services/smee.ts
@@ -33,7 +33,9 @@ class WebhookService {
       this.options.url = await this.createSmeeWebhookUrl();
     }
 
-    if (this.options.url.includes('smee.io')) {
+    const parsedUrl = new URL(this.options.url);
+    const allowedHosts = ['smee.io', 'www.smee.io'];
+    if (allowedHosts.includes(parsedUrl.host)) {
       logger.info(`Using Smee to receive webhooks ${this.options.url}`);
       try {
         const SmeeClient = (await import("smee-client")).default;


### PR DESCRIPTION
Potential fix for [https://github.com/austenstone/github-value/security/code-scanning/1186](https://github.com/austenstone/github-value/security/code-scanning/1186)

To fix the problem, we need to parse the URL and check the host value explicitly. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the check by embedding 'smee.io' in unexpected locations.

- Parse the URL using the `URL` constructor to extract the host.
- Check if the host is exactly 'smee.io' or one of its subdomains.
- Update the condition on line 36 to use this parsed host value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
