### PR TITLE
Add log rotation settings

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -19,3 +19,10 @@ MONGODB_URI=mongodb://localhost:27017/github-value
 # Webhook proxy URL (optional)
 # This is only needed if you don't want to use smee.io
 # WEBHOOK_PROXY_URL=https://5950-2601-589-4885-e850-b1eb-a754-b856-6038.ngrok-free.app
+#
+
+# Log rotation settings
+# In observing organizations with large amounts of activity, the debug logs can
+# grow quite large, so having flexibility about how long to store those helps.
+# LOG_ROTATION_PERIOD=1d
+# LOG_ROTATION_COUNT=14

--- a/backend/src/services/logger.ts
+++ b/backend/src/services/logger.ts
@@ -2,6 +2,7 @@ import bunyan from 'bunyan';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { Request, Response, NextFunction } from 'express';
 import path, { dirname } from 'path';
+import process from 'node:process';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -15,6 +16,9 @@ if (!existsSync(logsDir)) {
 const packageJsonPath = path.resolve(__dirname, '../../package.json');
 const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
 export const appName = packageJson.name || 'GitHub Value';
+
+const period = process.env.LOG_ROTATION_PERIOD || '1d';
+const count = parseInt(process.env.LOG_ROTATION_COUNT ?? '14');
 
 const logger = bunyan.createLogger({
   name: appName,
@@ -42,14 +46,16 @@ const logger = bunyan.createLogger({
     },
     {
       path: `${logsDir}/error.json`,
-      period: '1d',
-      count: 14,
+      type: 'rotating-file',
+      period: period,
+      count: count,
       level: 'error'
     },
     {
       path: `${logsDir}/debug.json`,
-      period: '1d',
-      count: 14,
+      type: 'rotating-file',
+      period: period,
+      count: count,
       level: 'debug'
     }
   ]

--- a/compose.yml
+++ b/compose.yml
@@ -10,6 +10,8 @@ services:
       NODE_ENV: production
       NODE_OPTIONS: --enable-source-maps
       MONGODB_URI: mongodb://root:octocat@mongo:27017
+    env_file:
+      - backend/.env
     depends_on:
       mongo:
         condition: service_healthy


### PR DESCRIPTION
This is at least a _partial_ fix for:
*  #178 

(I'm testing this today, will comment further on how it goes)

I see the support for `backend/.env` had been removed in `compose.yml` also recently - but this is really useful for setting non-default settings, so this adds it back.